### PR TITLE
RP-5658: Send a resync event before returning ErrCacheMiss

### DIFF
--- a/cached.go
+++ b/cached.go
@@ -302,6 +302,19 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 	if miss {
 		// this can be deceiving as sometimes the client might be
 		// ahead of the server and in fact be too early.
+		resyncEvent := Event{
+			ID: lastServerID,
+			Data: map[string]interface{}{
+				"message": "resync required",
+			},
+		}
+
+		Respond(ctx, w,
+			prependStream([]Event{resyncEvent}, nil),
+			&s.cfg,
+			s.responseStop,
+		)
+
 		return ErrCacheMiss
 	}
 

--- a/cached.go
+++ b/cached.go
@@ -299,10 +299,10 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 		s.cfg.ResyncEventsThreshold,
 		f,
 	)
+
 	if miss {
 		// this can be deceiving as sometimes the client might be
 		// ahead of the server and in fact be too early.
-
 		resyncEvent := Event{
 			ID: lastServerID,
 			Data: map[string]interface{}{
@@ -311,7 +311,6 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 		}
 
 		err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
-
 		if err != nil {
 			return err
 		}

--- a/cached.go
+++ b/cached.go
@@ -303,7 +303,7 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 	if miss {
 		// this can be deceiving as sometimes the client might be
 		// ahead of the server and in fact be too early.
-		err := Respond(ctx, w, prependStream([]Event{NewErrorEvent(ResyncRequiredError, map[string]interface{}{})}, nil), &s.cfg, s.responseStop)
+		err := Respond(ctx, w, prependStream([]Event{ResyncRequiredErrorEvent()}, nil), &s.cfg, s.responseStop)
 		if err != nil {
 			return err
 		}

--- a/cached.go
+++ b/cached.go
@@ -303,14 +303,7 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 	if miss {
 		// this can be deceiving as sometimes the client might be
 		// ahead of the server and in fact be too early.
-		resyncEvent := Event{
-			ID: lastServerID,
-			Data: map[string]interface{}{
-				"message": "resync required",
-			},
-		}
-
-		err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+		err := Respond(ctx, w, prependStream([]Event{NewErrorEvent(ResyncRequiredError, map[string]interface{}{})}, nil), &s.cfg, s.responseStop)
 		if err != nil {
 			return err
 		}

--- a/cached.go
+++ b/cached.go
@@ -308,7 +308,11 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 				"message": "resync required",
 			},
 		}
-		Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+		err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+		if err != nil {
+			return err
+		}
+
 		return ErrCacheMiss
 	}
 

--- a/cached.go
+++ b/cached.go
@@ -302,13 +302,16 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 	if miss {
 		// this can be deceiving as sometimes the client might be
 		// ahead of the server and in fact be too early.
+
 		resyncEvent := Event{
 			ID: lastServerID,
 			Data: map[string]interface{}{
 				"message": "resync required",
 			},
 		}
+
 		err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+
 		if err != nil {
 			return err
 		}

--- a/cached.go
+++ b/cached.go
@@ -308,13 +308,7 @@ func (s *CachedStream) SubscribeTopicFiltered(ctx context.Context, w http.Respon
 				"message": "resync required",
 			},
 		}
-
-		Respond(ctx, w,
-			prependStream([]Event{resyncEvent}, nil),
-			&s.cfg,
-			s.responseStop,
-		)
-
+		Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
 		return ErrCacheMiss
 	}
 

--- a/cached_test.go
+++ b/cached_test.go
@@ -132,7 +132,7 @@ func TestCachedError(t *testing.T) {
 	w := httptest.NewRecorder()
 	// resyncing from non-existent event ID should return error
 	err := stream.Subscribe(t.Context(), w, "non-existent")
-	assertReceivedEvents(t, w, NewErrorEvent(ResyncRequiredError, map[string]interface{}{}))
+	assertReceivedEvents(t, w, ResyncRequiredErrorEvent())
 	if !errors.Is(err, ErrCacheMiss) {
 		t.Errorf("Expected error: %v, got: %v", ErrCacheMiss, err)
 	}

--- a/cached_test.go
+++ b/cached_test.go
@@ -132,6 +132,7 @@ func TestCachedError(t *testing.T) {
 	w := httptest.NewRecorder()
 	// resyncing from non-existent event ID should return error
 	err := stream.Subscribe(t.Context(), w, "non-existent")
+	assertReceivedEvents(t, w, NewErrorEvent(ResyncRequiredError, map[string]interface{}{}))
 	if !errors.Is(err, ErrCacheMiss) {
 		t.Errorf("Expected error: %v, got: %v", ErrCacheMiss, err)
 	}

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -151,7 +151,7 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 		if !ok {
 			s.mu.RUnlock()
 
-			err := Respond(ctx, w, prependStream([]Event{NewErrorEvent(ResyncRequiredError, map[string]interface{}{})}, nil), &s.cfg, s.responseStop)
+			err := Respond(ctx, w, prependStream([]Event{ResyncRequiredErrorEvent()}, nil), &s.cfg, s.responseStop)
 			if err != nil {
 				return err
 			}

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -150,6 +150,18 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 		event, ok := s.events[topicIDKey(topic, lastEventID)]
 		if !ok {
 			s.mu.RUnlock()
+			resyncEvent := Event{
+				ID: lastServerID,
+				Data: map[string]interface{}{
+					"message": "resync required",
+				},
+			}
+
+			Respond(ctx, w,
+				prependStream([]Event{resyncEvent}, nil),
+				&s.cfg,
+				s.responseStop,
+			)
 
 			return ErrCacheMiss
 		}

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -156,13 +156,7 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 					"message": "resync required",
 				},
 			}
-
-			Respond(ctx, w,
-				prependStream([]Event{resyncEvent}, nil),
-				&s.cfg,
-				s.responseStop,
-			)
-
+			Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
 			return ErrCacheMiss
 		}
 

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -156,7 +156,12 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 					"message": "resync required",
 				},
 			}
-			Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+
+			err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+			if err != nil {
+				return err
+			}
+
 			return ErrCacheMiss
 		}
 

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -150,6 +150,7 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 		event, ok := s.events[topicIDKey(topic, lastEventID)]
 		if !ok {
 			s.mu.RUnlock()
+
 			resyncEvent := Event{
 				ID: lastServerID,
 				Data: map[string]interface{}{
@@ -158,6 +159,7 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 			}
 
 			err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+
 			if err != nil {
 				return err
 			}

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -150,6 +150,7 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 		event, ok := s.events[topicIDKey(topic, lastEventID)]
 		if !ok {
 			s.mu.RUnlock()
+
 			err := Respond(ctx, w, prependStream([]Event{NewErrorEvent(ResyncRequiredError, map[string]interface{}{})}, nil), &s.cfg, s.responseStop)
 			if err != nil {
 				return err

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -159,7 +159,6 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 			}
 
 			err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
-
 			if err != nil {
 				return err
 			}

--- a/cachedcount.go
+++ b/cachedcount.go
@@ -150,15 +150,7 @@ func (s *CachedCountStream) SubscribeTopicFiltered(ctx context.Context, w http.R
 		event, ok := s.events[topicIDKey(topic, lastEventID)]
 		if !ok {
 			s.mu.RUnlock()
-
-			resyncEvent := Event{
-				ID: lastServerID,
-				Data: map[string]interface{}{
-					"message": "resync required",
-				},
-			}
-
-			err := Respond(ctx, w, prependStream([]Event{resyncEvent}, nil), &s.cfg, s.responseStop)
+			err := Respond(ctx, w, prependStream([]Event{NewErrorEvent(ResyncRequiredError, map[string]interface{}{})}, nil), &s.cfg, s.responseStop)
 			if err != nil {
 				return err
 			}

--- a/cachedcount_test.go
+++ b/cachedcount_test.go
@@ -43,6 +43,7 @@ func TestCachedCountResync(t *testing.T) {
 	w = httptest.NewRecorder()
 	// cache size limit passed
 	err := stream.Subscribe(t.Context(), w, "first")
+	assertReceivedEvents(t, w, NewErrorEvent(ResyncRequiredError, map[string]interface{}{}))
 	if !errors.Is(err, ErrCacheMiss) {
 		t.Errorf("Expected error: %v, got: %v", ErrCacheMiss, err)
 	}
@@ -89,6 +90,7 @@ func TestCachedCountError(t *testing.T) {
 	w := httptest.NewRecorder()
 	// resyncing from non-existent event ID should return error
 	err := stream.Subscribe(t.Context(), w, "non existent")
+	assertReceivedEvents(t, w, NewErrorEvent(ResyncRequiredError, map[string]interface{}{}))
 	if !errors.Is(err, ErrCacheMiss) {
 		t.Errorf("Expected error: %v, got: %v", ErrCacheMiss, err)
 	}

--- a/cachedcount_test.go
+++ b/cachedcount_test.go
@@ -43,7 +43,7 @@ func TestCachedCountResync(t *testing.T) {
 	w = httptest.NewRecorder()
 	// cache size limit passed
 	err := stream.Subscribe(t.Context(), w, "first")
-	assertReceivedEvents(t, w, NewErrorEvent(ResyncRequiredError, map[string]interface{}{}))
+	assertReceivedEvents(t, w, ResyncRequiredErrorEvent())
 	if !errors.Is(err, ErrCacheMiss) {
 		t.Errorf("Expected error: %v, got: %v", ErrCacheMiss, err)
 	}
@@ -90,7 +90,7 @@ func TestCachedCountError(t *testing.T) {
 	w := httptest.NewRecorder()
 	// resyncing from non-existent event ID should return error
 	err := stream.Subscribe(t.Context(), w, "non existent")
-	assertReceivedEvents(t, w, NewErrorEvent(ResyncRequiredError, map[string]interface{}{}))
+	assertReceivedEvents(t, w, ResyncRequiredErrorEvent())
 	if !errors.Is(err, ErrCacheMiss) {
 		t.Errorf("Expected error: %v, got: %v", ErrCacheMiss, err)
 	}

--- a/writer.go
+++ b/writer.go
@@ -52,9 +52,11 @@ type Event struct {
 }
 
 const (
+	// ResyncRequiredError is the error type for resync required events.
 	ResyncRequiredError = "resyncRequired"
 )
 
+// NewErrorEvent creates a new error event with the specified error type and details.
 func NewErrorEvent(errorType string, details interface{}) Event {
 	return Event{
 		Event: "error",

--- a/writer.go
+++ b/writer.go
@@ -51,15 +51,26 @@ type Event struct {
 	Data  interface{} // Data value will be marshaled to JSON
 }
 
-// ResyncRequiredErrorEvent is the error event sent when a resync is required.
-func ResyncRequiredErrorEvent() Event {
+// ErrorEventData holds data for error event in SSE stream.
+type ErrorEventData struct {
+	Error string         `json:"error"`
+	Data  map[string]any `json:"data,omitempty"`
+}
+
+// ErrorEvent creates a new error event with given error type and optional details.
+func ErrorEvent(error string, data map[string]any) Event {
 	return Event{
 		Event: "error",
-		Data: map[string]any{
-			"error": "resyncRequired",
-			"data":  map[string]any{},
+		Data: ErrorEventData{
+			Error: error,
+			Data:  data,
 		},
 	}
+}
+
+// ResyncRequiredErrorEvent is the error event sent when a resync is required.
+func ResyncRequiredErrorEvent() Event {
+	return ErrorEvent("resyncRequired", nil)
 }
 
 // DefaultConfig is a recommended SSE configuration.

--- a/writer.go
+++ b/writer.go
@@ -51,6 +51,20 @@ type Event struct {
 	Data  interface{} // Data value will be marshaled to JSON
 }
 
+const (
+	ResyncRequiredError = "resyncRequired"
+)
+
+func NewErrorEvent(errorType string, details interface{}) Event {
+	return Event{
+		Event: "error",
+		Data: map[string]interface{}{
+			"error": errorType,
+			"data":  details,
+		},
+	}
+}
+
 // DefaultConfig is a recommended SSE configuration.
 var DefaultConfig = Config{
 	Reconnect:             500 * time.Millisecond,

--- a/writer.go
+++ b/writer.go
@@ -51,18 +51,13 @@ type Event struct {
 	Data  interface{} // Data value will be marshaled to JSON
 }
 
-const (
-	// ResyncRequiredError is the error type for resync required events.
-	ResyncRequiredError = "resyncRequired"
-)
-
-// NewErrorEvent creates a new error event with the specified error type and details.
-func NewErrorEvent(errorType string, details interface{}) Event {
+// ResyncRequiredErrorEvent is the error event sent when a resync is required.
+func ResyncRequiredErrorEvent() Event {
 	return Event{
 		Event: "error",
-		Data: map[string]interface{}{
-			"error": errorType,
-			"data":  details,
+		Data: map[string]any{
+			"error": "resyncRequired",
+			"data":  map[string]any{},
 		},
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -58,11 +58,11 @@ type ErrorEventData struct {
 }
 
 // ErrorEvent creates a new error event with given error type and optional details.
-func ErrorEvent(error string, data map[string]any) Event {
+func ErrorEvent(err string, data map[string]any) Event {
 	return Event{
 		Event: "error",
 		Data: ErrorEventData{
-			Error: error,
+			Error: err,
 			Data:  data,
 		},
 	}


### PR DESCRIPTION
When FE would get resync required error, they cant handle it and they aren't getting any status or message back. Implemented a solution where a synthetic "needs resync" event is sent to the FE , before the stream closes.

Closes  advbet/retail-roadmap/issues/5658